### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-win32-test.yml
+++ b/.github/workflows/pr-win32-test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/vscode/security/code-scanning/4](https://github.com/se2026/vscode/security/code-scanning/4)

To fix the problem, add an explicit `permissions` block to the workflow file to restrict the permissions of the `GITHUB_TOKEN`. Since the workflow does not appear to require write access to the repository, set `contents: read` at the root level of the workflow YAML, immediately after any `name:` (if present) and before `on:`. This ensures all jobs default to these minimal permissions unless overridden. If any steps require additional permissions (write access for pull requests, issues, etc.), these should be granted specifically at the job level, but the provided workflow does not contain any such operations. No changes to existing functionality are required.

**What needs to be changed:**  
- Edit `.github/workflows/pr-win32-test.yml`
- Add the block:
  ```yaml
  permissions:
    contents: read
  ```
  at the root, before `on:`.

No additional dependencies or method definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
