### PR TITLE
Potential fix for code scanning alert no. 67: Inefficient regular expression

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
@@ -98,7 +98,7 @@ export function detectsCommonPromptPattern(cursorLine: string): IPromptDetection
 
 
 // PowerShell-style multi-option line (supports [?] Help and optional default suffix) ending in whitespace
-const PS_CONFIRM_RE = /\s*(?:\[[^\]]\]\s+[^\[]+\s*)+(?:\(default is\s+"[^"]+"\):)?\s+$/;
+const PS_CONFIRM_RE = /\s*(?:\[[^\]]\]\s+[^\]]+\s*)+(?:\(default is\s+"[^"]+"\):)?\s+$/;
 
 // Bracketed/parenthesized yes/no pairs at end of line: (y/n), [Y/n], (yes/no), [no/yes]
 const YN_PAIRED_RE = /(?:\(|\[)\s*(?:y(?:es)?\s*\/\s*n(?:o)?|n(?:o)?\s*\/\s*y(?:es)?)\s*(?:\]|\))\s+$/i;


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/vscode/security/code-scanning/67](https://github.com/se2026/vscode/security/code-scanning/67)

**How to fix:**  
To remedy the exponential backtracking in the regular expression, we should remove ambiguity inside `[^\[]+`. The intent seems to be to match "anything except a left square bracket." In fact, the regexp should likely use `[^\]]+` (note the closing bracket), as the inner `[^\]]` matches any character except `]`—the expected content of an option inside square brackets like `[Y]`.

Assuming the pattern is to match multi-option PowerShell prompts such as `[Y] Yes  [N] No`, the current pattern incorrectly writes `[^\[]+`, which means "any run of characters except '['", which does not appropriately match the content after the label. Instead, the correct fix is to change `[^\[]+` to `[^\]]+`. Furthermore, in the outer grouping, we should confirm whether using `+` versus `*` is appropriate (to minimize ambiguous matches), but the critical fix is the incorrect use of `[^\[]`.

Edit line 101 of `src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts`:
- Change `[^\[]+` to `[^\]]+` in the regular expression.
- This removes the ambiguity because `[^\]]+` cannot match the character `]`, so the repeated groups are now unambiguous.

No additional imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
