### PR TITLE
Potential fix for code scanning alert no. 35: Use of a broken or weak cryptographic algorithm

### DIFF
--- a/src/vs/platform/languagePacks/node/languagePacks.ts
+++ b/src/vs/platform/languagePacks/node/languagePacks.ts
@@ -170,11 +170,11 @@ class LanguagePacksCache extends Disposable {
 
 	private updateHash(languagePack: ILanguagePack): void {
 		if (languagePack) {
-			const md5 = createHash('md5'); // CodeQL [SM04514] Used to create an hash for language pack extension version, which is not a security issue
+			const sha256 = createHash('sha256'); // Use strong hash for better collision resistance
 			for (const extension of languagePack.extensions) {
-				md5.update(extension.extensionIdentifier.uuid || extension.extensionIdentifier.id).update(extension.version); // CodeQL [SM01510] The extension UUID is not sensitive info and is not manually created by a user
+				sha256.update(extension.extensionIdentifier.uuid || extension.extensionIdentifier.id).update(extension.version);
 			}
-			languagePack.hash = md5.digest('hex');
+			languagePack.hash = sha256.digest('hex');
 		}
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/vscode/security/code-scanning/35](https://github.com/se2026/vscode/security/code-scanning/35)

To address the flagged issue, replace uses of the `md5` algorithm with a stronger, modern hash function such as SHA-256. This can be done by changing the call on line 173 from `createHash('md5')` to `createHash('sha256')`. Since Node.js' `crypto` module natively supports SHA-256, and the rest of the logic (updating the hash, digesting as hex) does not have to change, it is a safe substitution. The changes are localized to the `updateHash` method in `src/vs/platform/languagePacks/node/languagePacks.ts`, lines 171-179.

No additional imports or logic is required, as `createHash` already supports SHA-256.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
